### PR TITLE
Prevent the first item in the autocomplete list from being selected automatically.

### DIFF
--- a/src/components/NewTimeEntryInput.vue
+++ b/src/components/NewTimeEntryInput.vue
@@ -153,6 +153,7 @@ export default defineComponent({
         minLength: 0,
         debounceWaitMs: 100,
         showOnFocus: true,
+        disableAutoSelect: true,
         fetch: async (text, callback) => {
           if (!text.includes("#") && !text.includes("@")) {
             return callback(await suggestTimeEntries(text));

--- a/src/components/TimeEntryAutocompleteInput.vue
+++ b/src/components/TimeEntryAutocompleteInput.vue
@@ -143,6 +143,7 @@ export default defineComponent({
         minLength: 0,
         debounceWaitMs: 100,
         showOnFocus: true,
+        disableAutoSelect: true,
         fetch: async (text, callback) => {
           if (!text.includes("#") && !text.includes("@")) {
             return callback(await suggestTimeEntries(text));


### PR DESCRIPTION
Until now, when updating the description of a time entry, the first item of the autocomplete list is preselected. Pressing ENTER therefore overwrites the text that was entered manually. As the autoselect items take some time to refresh, manually entering e.g. "Documentation" and pressing ENTER might select e.g. "Dashboard changes" from another project, causing confusion.

This change allows for submitting a custom text by pressing ENTER even when autocomplete items are displayed. Selecting and navigating autocomplete items using the arrow keys still works.